### PR TITLE
chore: unify exception messages and KDoc to English

### DIFF
--- a/annotation/src/main/kotlin/io/clroot/excel/annotation/style/StyleEnums.kt
+++ b/annotation/src/main/kotlin/io/clroot/excel/annotation/style/StyleEnums.kt
@@ -5,8 +5,8 @@ import io.clroot.excel.core.style.BorderStyle
 import io.clroot.excel.core.style.Color
 
 /**
- * 미리 정의된 색상 상수.
- * 커스텀 색상이 필요하면 `backgroundColorHex = "#RRGGBB"` 사용.
+ * Predefined color constants.
+ * For custom colors, use `backgroundColorHex = "#RRGGBB"`.
  */
 enum class StyleColor(internal val rgb: Triple<Int, Int, Int>?) {
     NONE(null),
@@ -25,7 +25,7 @@ enum class StyleColor(internal val rgb: Triple<Int, Int, Int>?) {
 }
 
 /**
- * 텍스트 정렬 옵션.
+ * Text alignment options.
  */
 enum class StyleAlignment {
     NONE,
@@ -44,7 +44,7 @@ enum class StyleAlignment {
 }
 
 /**
- * 테두리 스타일 옵션.
+ * Border style options.
  */
 enum class StyleBorder {
     NONE,

--- a/core/src/main/kotlin/io/clroot/excel/core/dsl/SheetBuilder.kt
+++ b/core/src/main/kotlin/io/clroot/excel/core/dsl/SheetBuilder.kt
@@ -222,7 +222,7 @@ class SheetBuilder<T>(private val name: String) {
      *
      * Example:
      * ```kotlin
-     * column("가격", conditionalStyle = { value: Int? ->
+     * column("Price", conditionalStyle = { value: Int? ->
      *     when {
      *         value == null -> null
      *         value < 0 -> fontColor(Color.RED)
@@ -272,7 +272,7 @@ class SheetBuilder<T>(private val name: String) {
      * Example:
      * ```kotlin
      * column(
-     *     "가격",
+     *     "Price",
      *     bodyStyle = { bold() },
      *     conditionalStyle = { value: Int? ->
      *         if (value != null && value < 0) fontColor(Color.RED) else null

--- a/core/src/main/kotlin/io/clroot/excel/core/dsl/StyleFactories.kt
+++ b/core/src/main/kotlin/io/clroot/excel/core/dsl/StyleFactories.kt
@@ -11,7 +11,7 @@ import io.clroot.excel.core.style.Color
  *
  * Example:
  * ```kotlin
- * column("가격", conditionalStyle = { value: Int? ->
+ * column("Price", conditionalStyle = { value: Int? ->
  *     if (value != null && value < 0) fontColor(Color.RED) else null
  * }) { it.price }
  * ```
@@ -27,8 +27,8 @@ fun fontColor(color: Color): CellStyle = CellStyle(fontColor = color)
  *
  * Example:
  * ```kotlin
- * column("상태", conditionalStyle = { value: String? ->
- *     if (value == "경고") backgroundColor(Color.YELLOW) else null
+ * column("Status", conditionalStyle = { value: String? ->
+ *     if (value == "WARNING") backgroundColor(Color.YELLOW) else null
  * }) { it.status }
  * ```
  *

--- a/core/src/main/kotlin/io/clroot/excel/core/model/ConditionalStyle.kt
+++ b/core/src/main/kotlin/io/clroot/excel/core/model/ConditionalStyle.kt
@@ -13,7 +13,7 @@ import io.clroot.excel.core.style.CellStyle
  *
  * Example:
  * ```kotlin
- * column("금액") {
+ * column("Amount") {
  *     conditionalStyle { value: Int ->
  *         when {
  *             value < 0 -> CellStyle(fontColor = Color.RED)

--- a/core/src/main/kotlin/io/clroot/excel/core/model/ExcelDocument.kt
+++ b/core/src/main/kotlin/io/clroot/excel/core/model/ExcelDocument.kt
@@ -93,7 +93,7 @@ sealed class ColumnWidth {
 
 /**
  * Extension property to create Fixed column width.
- * Usage: column("이름", width = 20.chars) { it.name }
+ * Usage: column("Name", width = 20.chars) { it.name }
  */
 val Int.chars: ColumnWidth get() = ColumnWidth.Fixed(this)
 

--- a/core/src/main/kotlin/io/clroot/excel/core/model/Formula.kt
+++ b/core/src/main/kotlin/io/clroot/excel/core/model/Formula.kt
@@ -8,8 +8,8 @@ package io.clroot.excel.core.model
  *
  * Example:
  * ```kotlin
- * column("합계") { formula("SUM(A2:A100)") }
- * column("평균") { formula("=AVERAGE(B2:B100)") }  // Leading '=' is optional
+ * column("Total") { formula("SUM(A2:A100)") }
+ * column("Average") { formula("=AVERAGE(B2:B100)") }  // Leading '=' is optional
  * ```
  *
  * @property expression the original formula expression as provided

--- a/parser/src/main/kotlin/io/clroot/excel/parser/CellConverter.kt
+++ b/parser/src/main/kotlin/io/clroot/excel/parser/CellConverter.kt
@@ -58,7 +58,7 @@ class CellConverter(
                 return null
             } else {
                 throw IllegalArgumentException(
-                    "${targetType.simpleName} 타입은 null을 허용하지 않지만, 셀 값이 비어있습니다.",
+                    "${targetType.simpleName} does not allow null, but cell value is empty.",
                 )
             }
         }
@@ -71,7 +71,7 @@ class CellConverter(
                 return null
             } else {
                 throw IllegalArgumentException(
-                    "${targetType.simpleName} 타입은 null을 허용하지 않지만, 셀 값이 비어있습니다.",
+                    "${targetType.simpleName} does not allow null, but cell value is empty.",
                 )
             }
         }

--- a/parser/src/main/kotlin/io/clroot/excel/parser/ExcelParser.kt
+++ b/parser/src/main/kotlin/io/clroot/excel/parser/ExcelParser.kt
@@ -83,7 +83,7 @@ internal class ExcelParserImpl<T : Any>(
                         ParseError(
                             rowIndex = config.headerRow,
                             columnHeader = it.header,
-                            message = "필수 컬럼 '${it.header}'을(를) 찾을 수 없습니다.",
+                            message = "Required column '${it.header}' not found.",
                         )
                     }
                 return ParseResult.Failure(missingErrors)

--- a/parser/src/test/kotlin/io/clroot/excel/parser/CellConverterTest.kt
+++ b/parser/src/test/kotlin/io/clroot/excel/parser/CellConverterTest.kt
@@ -27,7 +27,7 @@ class CellConverterTest : DescribeSpec({
                 shouldThrow<IllegalArgumentException> {
                     converter.convert(null, String::class, isNullable = false)
                 }
-            exception.message shouldContain "null을 허용하지 않지만"
+            exception.message shouldContain "does not allow null"
         }
 
         it("null은 null로 반환한다 (nullable=true)") {


### PR DESCRIPTION
## Summary

Prepare for 1.0.0 release by standardizing all user-facing messages to English.

## Changes

### Exception Messages
- `CellConverter.kt`: "타입은 null을 허용하지 않지만, 셀 값이 비어있습니다" → "does not allow null, but cell value is empty"
- `ExcelParser.kt`: "필수 컬럼 '...'을(를) 찾을 수 없습니다" → "Required column '...' not found"

### KDoc Comments
- `StyleEnums.kt`: Color, alignment, border enum descriptions
- `StyleFactories.kt`, `SheetBuilder.kt`: Example code column names
- `ConditionalStyle.kt`, `Formula.kt`, `ExcelDocument.kt`: Example code

### Tests
- `CellConverterTest.kt`: Updated assertion to match English message